### PR TITLE
Added Authentication Mode to Proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 name=proxy
 old_version=0.5.3
-version=0.5.3
+version=0.6.0
 
 build: clean
 	gem build conjur-asset-$(name).gemspec

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+name=proxy
+version=0.5.2
+
+build: clean
+	gem build conjur-asset-$(name).gemspec
+
+install: build
+	gem install conjur-asset-$(name)-$(version).gem
+	conjur plugin install -v $(version) $(name) 
+
+clean:
+	conjur plugin uninstall $(name)
+	rm conjur-asset-$(name)-$(version).gem
+
+show:
+	conjur plugin show $(name)

--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,3 @@ clean:
 test-conjur:
 	conjur proxy http://httpbin.org
 
-test-basic: 
-	conjur plugin show $(name)
-	conjur policy load --collection $(name)/$(version) test_basic/test-policy.rb
-	#conjur script execute --collection $(name)/$(version) test_basic/test-data.rb
-	conjur variable values add $(name)/$(version)/test/password test
-	conjur variable values add $(name)/$(version)/test/username test
-	conjur proxy --at basic \
-		--bu $(name)/$(version)/test/username \
-		--bp $(name)/$(version)/test/password \
-		http://browserspy.dk &
-	sleep 10
-	curl http://localhost:8080/password-ok.php | grep Success

--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,6 @@ clean:
 	mv /tmp/.conjurrc-$(name) ~/.conjurrc
 	rm conjur-asset-$(name)-$(old_version).gem
 
-show:
+test: 
 	conjur plugin show $(name)
+	conjur policy load --collection $(name)/$(version) policy.rb

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,18 @@ clean:
 	mv /tmp/.conjurrc-$(name) ~/.conjurrc
 	rm conjur-asset-$(name)-$(old_version).gem
 
-test: 
+test-conjur:
+	conjur proxy http://httpbin.org
+
+test-basic: 
 	conjur plugin show $(name)
-	conjur policy load --collection $(name)/$(version) policy.rb
+	conjur policy load --collection $(name)/$(version) test_basic/test-policy.rb
+	#conjur script execute --collection $(name)/$(version) test_basic/test-data.rb
+	conjur variable values add $(name)/$(version)/test/password test
+	conjur variable values add $(name)/$(version)/test/username test
 	conjur proxy --at basic \
 		--bu $(name)/$(version)/test/username \
 		--bp $(name)/$(version)/test/password \
-		http://httpbin.org &
+		http://browserspy.dk &
+	sleep 10
+	curl http://localhost:8080/password-ok.php | grep Success

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ test:
 	conjur proxy --at basic \
 		--bu $(name)/$(version)/test/username \
 		--bp $(name)/$(version)/test/password \
-		http://www.foo.com 
+		http://httpbin.org &

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ install: build
 	conjur plugin install -v $(version) $(name) 
 
 clean:
-	conjur plugin uninstall $(name)
+	#conjur plugin uninstall fails when there is
+	#a bug in the plugin, so we need to manuall remove the plugin
+	cat ~/.conjurrc | grep -v $(name) > /tmp/.conjurrc-$(name)
+	mv /tmp/.conjurrc-$(name) ~/.conjurrc
 	rm conjur-asset-$(name)-$(old_version).gem
 
 show:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 name=proxy
-version=0.5.2
+old_version=0.5.3
+version=0.5.3
 
 build: clean
 	gem build conjur-asset-$(name).gemspec
@@ -10,7 +11,7 @@ install: build
 
 clean:
 	conjur plugin uninstall $(name)
-	rm conjur-asset-$(name)-$(version).gem
+	rm conjur-asset-$(name)-$(old_version).gem
 
 show:
 	conjur plugin show $(name)

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ clean:
 	#a bug in the plugin, so we need to manuall remove the plugin
 	cat ~/.conjurrc | grep -v $(name) > /tmp/.conjurrc-$(name)
 	mv /tmp/.conjurrc-$(name) ~/.conjurrc
+	touch conjur-asset-$(name)-$(old_version).gem
 	rm conjur-asset-$(name)-$(old_version).gem
 
 test-conjur:

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,7 @@ clean:
 test: 
 	conjur plugin show $(name)
 	conjur policy load --collection $(name)/$(version) policy.rb
+	conjur proxy --at basic \
+		--bu $(name)/$(version)/test/username \
+		--bp $(name)/$(version)/test/password \
+		http://www.foo.com 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,27 @@ Simple HTTP proxy which adds Conjur authentication headers.
 
     Conjur proxy to http://protected-service.example.com started on http://localhost:32123
     Press Ctrl-C to stop.
-
+## Working with Plugins
+To change the version of the plugin - you modify the lib/conjur/asset/proxy/version.rb file
+'''
+module Conjur
+  module Asset
+    module Proxy
+      VERSION = "0.5.3"
+    end
+  end
+end
+'''
+To change the description when you run conjur plugin show, modify the conjur-asset-proxy.gemspec
+'''
+  spec.name          = "conjur-asset-proxy"
+  spec.version       = Conjur::Asset::Proxy::VERSION
+  spec.authors       = ["Rafa Rzepecki", "Mikalai Sevastsyana","Josh Bregman"]
+  spec.email         = ["rafal@conjur.net", "mikalai@conjur.net","josh.bregman@conjur.net"]
+  spec.summary       = %q{Simple HTTP proxy which adds authentication headers from Conjur"}
+  spec.homepage      = "https://github.com/conjurinc/conjur-asset-proxy"
+  spec.license       = "MIT"
+'''
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/conjur-asset-proxy/fork )

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simple HTTP proxy which adds Conjur authentication headers.
     Press Ctrl-C to stop.
 ## Working with Plugins
 To change the version of the plugin - you modify the lib/conjur/asset/proxy/version.rb file
-'''
+```
 module Conjur
   module Asset
     module Proxy
@@ -22,9 +22,9 @@ module Conjur
     end
   end
 end
-'''
+```
 To change the description when you run conjur plugin show, modify the conjur-asset-proxy.gemspec
-'''
+```
   spec.name          = "conjur-asset-proxy"
   spec.version       = Conjur::Asset::Proxy::VERSION
   spec.authors       = ["Rafa Rzepecki", "Mikalai Sevastsyana","Josh Bregman"]
@@ -32,7 +32,7 @@ To change the description when you run conjur plugin show, modify the conjur-ass
   spec.summary       = %q{Simple HTTP proxy which adds authentication headers from Conjur"}
   spec.homepage      = "https://github.com/conjurinc/conjur-asset-proxy"
   spec.license       = "MIT"
-'''
+```
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/conjur-asset-proxy/fork )

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ task :headers do
   args = {
     :license => 'MIT',
     :copyright_software => 'Conjur CLI proxy plugin',
-    :copyright_software_description => "Simple HTTP proxy which adds authentication headers from Conjur authentication headers",
+    :copyright_software_description => "Simple HTTP proxy which adds authentication headers from Conjurs",
     :copyright_holders => ['Conjur Inc.'],
     :copyright_years => ['2016'],
     :add_path => 'lib',

--- a/Rakefile
+++ b/Rakefile
@@ -8,9 +8,9 @@ task :headers do
   args = {
     :license => 'MIT',
     :copyright_software => 'Conjur CLI proxy plugin',
-    :copyright_software_description => "Simple HTTP proxy which adds Conjur authentication headers",
+    :copyright_software_description => "Simple HTTP proxy which adds authentication headers from Conjur authentication headers",
     :copyright_holders => ['Conjur Inc.'],
-    :copyright_years => ['2014'],
+    :copyright_years => ['2016'],
     :add_path => 'lib',
     :output_dir => './'
   }

--- a/conjur-asset-proxy.gemspec
+++ b/conjur-asset-proxy.gemspec
@@ -6,9 +6,9 @@ require 'conjur/asset/proxy/version'
 Gem::Specification.new do |spec|
   spec.name          = "conjur-asset-proxy"
   spec.version       = Conjur::Asset::Proxy::VERSION
-  spec.authors       = ["Rafał Rzepecki", "Mikalai Sevastsyanau"]
-  spec.email         = ["rafal@conjur.net", "mikalai@conjur.net"]
-  spec.summary       = %q{Simple HTTP proxy which adds Conjur authentication headers}
+  spec.authors       = ["Rafał Rzepecki", "Mikalai Sevastsyana","Josh Bregman"]
+  spec.email         = ["rafal@conjur.net", "mikalai@conjur.net","josh.bregman@conjur.net"]
+  spec.summary       = %q{Simple HTTP proxy which adds authentication headers from Conjur"}
   spec.homepage      = "https://github.com/conjurinc/conjur-asset-proxy"
   spec.license       = "MIT"
 

--- a/lib/conjur/asset/proxy/version.rb
+++ b/lib/conjur/asset/proxy/version.rb
@@ -21,7 +21,7 @@
 module Conjur
   module Asset
     module Proxy
-      VERSION = "0.5.2"
+      VERSION = "0.5.3"
     end
   end
 end

--- a/lib/conjur/command/proxy.rb
+++ b/lib/conjur/command/proxy.rb
@@ -65,6 +65,11 @@ The proxy will keep running until terminated.
       #check the auth_type
       if options[:at] == "basic"
 
+	username = options[:bu]
+	if username.nil? || username.blank?
+		help_now!("-bu is required for -at basic")
+	end
+
       elsif options[:at] == "conjur"
 
       else

--- a/lib/conjur/command/proxy.rb
+++ b/lib/conjur/command/proxy.rb
@@ -65,18 +65,31 @@ The proxy will keep running until terminated.
       #check the auth_type
       if options[:at] == "basic"
 
+
 	username = options[:bu]
 	if username.nil? || username.blank?
-		help_now!("-bu is required for -at basic")
+		help_now!("--bu is required for --at basic")
 	else 
-		#check if the user has execute permission on the variable
+		#check if the proxy has execute permission on the variable
 		username_resource = api.variable(username).resource
 
 		if !(username_resource.permitted? 'execute')
-			help_now!("User does not have execute permission on "+username)
+			help_now!("proxy does not have execute permission on "+username)
 		end
 	end
 
+
+	password = options[:bp]
+	if password.nil? || password.blank?
+		help_now!("--bp is required for --at basic")
+	else 
+		#check if the proxy has execute permission on the variable
+		password_resource = api.variable(password).resource
+
+		if !(password_resource.permitted? 'execute')
+			help_now!("proxy does not have execute permission on "+password)
+		end
+	end
       elsif options[:at] == "conjur"
 
       else

--- a/lib/conjur/command/proxy.rb
+++ b/lib/conjur/command/proxy.rb
@@ -91,7 +91,7 @@ The proxy will keep running until terminated.
 		end
 	end
       elsif options[:t] == "conjur"
-
+	## NOOP
       else
 	help_now!("Invalid auth_type: #{options[:t]}")
       end

--- a/lib/conjur/command/proxy.rb
+++ b/lib/conjur/command/proxy.rb
@@ -22,10 +22,14 @@
 class Conjur::Command::Proxy < Conjur::Command
   desc "Proxy to a protected HTTP service"
   long_desc <<-DESC
-Launch an HTTP proxy to a Conjur-protected service. The proxy adds a Conjur
-authorization header to every request. This allows eg. using browser to access
-a UI of a Conjur-protected web application. The proxy will keep running until
-terminated.
+Launch an HTTP proxy to a protected service. 
+
+If the service is protected by Conjur, then the proxy adds a Conjur authorization header to every request. This allows eg. using browser to access
+a UI of a Conjur-protected web application.
+
+If the service is protected by basic authentication, then the proxy retrives the username and password from Conjur, and adds them to the authorization header of every request.  
+
+The proxy will keep running until terminated.
   DESC
 
   arg :url
@@ -44,6 +48,16 @@ terminated.
 
     c.flag :cacert,
         desc: "Verify SSL using the provided cert file"
+    
+    c.flag :bu, :basic_username,
+	desc: "Conjur resource for the username added to the basic authorization header"
+
+    c.flag :bp, :basic_password,
+	desc: "Conjur resource for the password added to the basic authorzation header"
+
+    c.flag :at, :auth_type,
+	desc: "The authentication type for the proxy - conjur or basic",
+	default_value: "conjur"
 
     c.action do |global_options, options, args|
       url = args.shift or help_now!("missing URL")

--- a/lib/conjur/command/proxy.rb
+++ b/lib/conjur/command/proxy.rb
@@ -68,6 +68,13 @@ The proxy will keep running until terminated.
 	username = options[:bu]
 	if username.nil? || username.blank?
 		help_now!("-bu is required for -at basic")
+	else 
+		#check if the user has execute permission on the variable
+		username_resource = api.variable(username).resource
+
+		if !(username_resource.permitted? 'execute')
+			help_now!("User does not have execute permission on "+username)
+		end
 	end
 
       elsif options[:at] == "conjur"

--- a/lib/conjur/command/proxy.rb
+++ b/lib/conjur/command/proxy.rb
@@ -49,13 +49,13 @@ The proxy will keep running until terminated.
     c.flag :cacert,
         desc: "Verify SSL using the provided cert file"
     
-    c.flag :bu, :basic_username,
-	desc: "Conjur resource for the username added to the basic authorization header"
+    c.flag :u, :basic_username,
+	desc: "Conjur variable for the username added to the basic authorization header"
 
-    c.flag :bp, :basic_password,
-	desc: "Conjur resource for the password added to the basic authorzation header"
+    c.flag :w, :basic_password,
+	desc: "Conjur variable for the password added to the basic authorzation header"
 
-    c.flag :at, :auth_type,
+    c.flag :t, :auth_type,
 	desc: "The authentication type for the proxy - conjur or basic",
 	default_value: "conjur"
 
@@ -63,37 +63,37 @@ The proxy will keep running until terminated.
       url = args.shift or help_now!("missing URL")
       
       #check the auth_type
-      if options[:at] == "basic"
+      if options[:t] == "basic"
 
 
-	username = options[:bu]
-	if username.nil? || username.blank?
-		help_now!("--bu is required for --at basic")
+	username = options[:u]
+	if username.blank?
+		help_now!("--u is required for --t basic")
 	else 
 		#check if the proxy has execute permission on the variable
 		username_resource = api.variable(username).resource
 
-		if !(username_resource.permitted? 'execute')
-			help_now!("proxy does not have execute permission on "+username)
+		unless username_resource.permitted? 'execute'
+			help_now!("proxy does not have execute permission on #{username}")
 		end
 	end
 
 
-	password = options[:bp]
-	if password.nil? || password.blank?
-		help_now!("--bp is required for --at basic")
+	password = options[:w]
+	if password.blank?
+		help_now!("--w is required for --t basic")
 	else 
 		#check if the proxy has execute permission on the variable
 		password_resource = api.variable(password).resource
 
-		if !(password_resource.permitted? 'execute')
-			help_now!("proxy does not have execute permission on "+password)
+		unless password_resource.permitted? 'execute'
+			help_now!("proxy does not have execute permission on #{password}")
 		end
 	end
-      elsif options[:at] == "conjur"
+      elsif options[:t] == "conjur"
 
       else
-	help_now!("Invalid auth_type: "+options[:at])
+	help_now!("Invalid auth_type: #{options[:t]}")
       end
 
       if options[:k]
@@ -112,7 +112,7 @@ The proxy will keep running until terminated.
 
       url = uri.to_s
 
-      options.slice! :port, :address, :insecure, :cacert, :at, :bu, :bp
+      options.slice! :port, :address, :insecure, :cacert, :t, :u, :w
       options.delete :port unless options[:port].respond_to? :to_i
 
       require 'conjur/proxy'

--- a/lib/conjur/command/proxy.rb
+++ b/lib/conjur/command/proxy.rb
@@ -61,6 +61,15 @@ The proxy will keep running until terminated.
 
     c.action do |global_options, options, args|
       url = args.shift or help_now!("missing URL")
+      
+      #check the auth_type
+      if options[:at] == "basic"
+
+      elsif options[:at] == "conjur"
+
+      else
+	help_now!("Invalid auth_type: "+options[:at])
+      end
 
       if options[:k]
         options[:insecure] = true

--- a/lib/conjur/command/proxy.rb
+++ b/lib/conjur/command/proxy.rb
@@ -112,11 +112,12 @@ The proxy will keep running until terminated.
 
       url = uri.to_s
 
-      options.slice! :port, :address, :insecure, :cacert
+      options.slice! :port, :address, :insecure, :cacert, :at, :bu, :bp
       options.delete :port unless options[:port].respond_to? :to_i
 
       require 'conjur/proxy'
-
+      print options
+      print "-------"
       Conjur::Proxy.new(url, api).start options
     end
   end

--- a/lib/conjur/proxy.rb
+++ b/lib/conjur/proxy.rb
@@ -36,9 +36,12 @@ module Conjur
 
         ret
       end
+      @auth_method = "conjur"
+      @basic_username = ""
+      @basic_password = ""
     end
 
-    attr_reader :proxy, :conjur
+    attr_reader :proxy, :conjur, :auth_method, :basic_username, :basic_password
 
     def call env
       env['HTTP_AUTHORIZATION'] = conjur.credentials[:headers][:authorization]

--- a/lib/conjur/proxy.rb
+++ b/lib/conjur/proxy.rb
@@ -48,9 +48,9 @@ module Conjur
     def call env
 	
 	if @auth_method == "basic"
-		header = Base64.encode64(@basic_username+':'+@basic_password)
+		header = Base64.strict_encode64(@basic_username+':'+@basic_password)
 		authorization_header = 'Basic '+header
-		env['HTTP_AUTHORIZATION'] = authorization_header.rstrip
+		env['HTTP_AUTHORIZATION'] = authorization_header
 	else
       		env['HTTP_AUTHORIZATION'] = conjur.credentials[:headers][:authorization]
 	end
@@ -100,16 +100,12 @@ module Conjur
         end
       end
 
-     print "====================================="
-     print options
-     print "====================================="
-
      #check if the auth method is basic
-     if options[:at] == "basic"
+     if options[:t] == "basic"
 
 	@auth_method = "basic"
-	@basic_username = @conjur.variable(options[:bu]).value
-	@basic_password = @conjur.variable(options[:bp]).value
+	@basic_username = @conjur.variable(options[:u]).value
+	@basic_password = @conjur.variable(options[:w]).value
 
 
      end

--- a/policy.rb
+++ b/policy.rb
@@ -1,0 +1,6 @@
+policy "test" do
+
+	variable "username"
+	variable "password"
+
+end

--- a/test-basic/Makefile
+++ b/test-basic/Makefile
@@ -1,6 +1,6 @@
 name=proxy
 old_version=0.5.3
-version=0.5.3
+version=0.6
 
 default: test
 

--- a/test-basic/Makefile
+++ b/test-basic/Makefile
@@ -1,18 +1,19 @@
 name=proxy
 old_version=0.5.3
-version=0.6
+version=0.8
 
 default: test
 
 test: 
-	conjur plugin show $(name)
-	conjur policy load --collection $(name)/$(version) test-policy.rb
+	conjur policy load --collection $(name)/$(version) --as-group security_admin test-policy.rb
+	conjur hostfactory create --as-group security_admin -l $(name)/$(version)/test/puppet puppethosts
+
 	#conjur script execute --collection $(name)/$(version) test-data.rb
-	conjur variable values add $(name)/$(version)/test/password test
-	conjur variable values add $(name)/$(version)/test/username test
-	conjur proxy -t basic \
-		-u $(name)/$(version)/test/username \
-		-w $(name)/$(version)/test/password \
-		http://browserspy.dk &
-	sleep 10
-	curl http://localhost:8080/password-ok.php | grep Success
+#	conjur variable values add $(name)/$(version)/test/password test
+#	conjur variable values add $(name)/$(version)/test/username test
+#	conjur proxy -t basic \
+#		-u $(name)/$(version)/test/username \
+#		-w $(name)/$(version)/test/password \
+#		http://browserspy.dk &
+#	sleep 10
+#	curl http://localhost:8080/password-ok.php | grep Success

--- a/test-basic/Makefile
+++ b/test-basic/Makefile
@@ -1,0 +1,18 @@
+name=proxy
+old_version=0.5.3
+version=0.5.3
+
+default: test
+
+test: 
+	conjur plugin show $(name)
+	conjur policy load --collection $(name)/$(version) test-policy.rb
+	#conjur script execute --collection $(name)/$(version) test-data.rb
+	conjur variable values add $(name)/$(version)/test/password test
+	conjur variable values add $(name)/$(version)/test/username test
+	conjur proxy --at basic \
+		--bu $(name)/$(version)/test/username \
+		--bp $(name)/$(version)/test/password \
+		http://browserspy.dk &
+	sleep 10
+	curl http://localhost:8080/password-ok.php | grep Success

--- a/test-basic/Makefile
+++ b/test-basic/Makefile
@@ -10,9 +10,9 @@ test:
 	#conjur script execute --collection $(name)/$(version) test-data.rb
 	conjur variable values add $(name)/$(version)/test/password test
 	conjur variable values add $(name)/$(version)/test/username test
-	conjur proxy --at basic \
-		--bu $(name)/$(version)/test/username \
-		--bp $(name)/$(version)/test/password \
+	conjur proxy -t basic \
+		-u $(name)/$(version)/test/username \
+		-w $(name)/$(version)/test/password \
 		http://browserspy.dk &
 	sleep 10
 	curl http://localhost:8080/password-ok.php | grep Success

--- a/test-basic/test-data.rb
+++ b/test-basic/test-data.rb
@@ -1,0 +1,2 @@
+api.variable("test/username").add_value 'test'
+api.variable("test/password").add_value 'test'

--- a/test-basic/test-policy.rb
+++ b/test-basic/test-policy.rb
@@ -1,6 +1,15 @@
 policy "test" do
 
-	variable "username"
-	variable "password"
+	username = variable "username"
+	password = variable "password"
 
+	layer "puppet" do
+
+		can 'read', username
+		can 'execute', username
+	
+		can 'read', password
+		can 'execute', password	
+
+	end 
 end

--- a/test-basic/test-policy.rb
+++ b/test-basic/test-policy.rb
@@ -1,0 +1,6 @@
+policy "test" do
+
+	variable "username"
+	variable "password"
+
+end


### PR DESCRIPTION
I added the -at option to handle basic authentication, and allow the proxy to not only produce a Conjur token, but also support username and password.  This allows Conjur to easily proxy to services protected by Basic Auth, but need to have the username and password secured by Conjur.
